### PR TITLE
Device List and System Info endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 
 from routers import user
 from routers import device_power
+from routers import device
 
 from dependencies import root_path
 
@@ -12,6 +13,7 @@ from dependencies import root_path
 app = FastAPI()
 app.include_router(user.router)
 app.include_router(device_power.router)
+app.include_router(device.router)
 
 
 @app.get(f'{root_path}/time')

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,6 +2,7 @@ from .devices_power_current_response import DevicesPowerCurrentResponse
 from .devices_power_day_response import DevicesPowerDayResponse
 from .devices_power_month_response import DevicesPowerMonthResponse
 from .device_response import DeviceResponse
+from .device_sys_info import DeviceSystemInfoResponse
 from .user_auth_token import UserAuthToken
 from .user import User
 
@@ -10,6 +11,7 @@ __all__ = [
     'DevicesPowerDayResponse',
     'DevicesPowerMonthResponse',
     'DeviceResponse',
+    'DeviceSystemInfoResponse',
     'UserAuthToken',
     'User'
 ]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
 from .devices_power_current_response import DevicesPowerCurrentResponse
 from .devices_power_day_response import DevicesPowerDayResponse
 from .devices_power_month_response import DevicesPowerMonthResponse
+from .device_response import DeviceResponse
 from .user_auth_token import UserAuthToken
 from .user import User
 
@@ -8,6 +9,7 @@ __all__ = [
     'DevicesPowerCurrentResponse',
     'DevicesPowerDayResponse',
     'DevicesPowerMonthResponse',
+    'DeviceResponse',
     'UserAuthToken',
     'User'
 ]

--- a/app/models/device_response.py
+++ b/app/models/device_response.py
@@ -1,27 +1,29 @@
 from typing import List, Optional
 from pydantic import BaseModel
 
+
 class DeviceInfo(BaseModel):
-    device_type: str        # "IOT.SMARTPLUGSWITCH",
-    role: int               # 0,
-    fw_ver: str             # "1.0.17 Build 210506 Rel.075231",
-    #"app_server_url":"https://use1-wap.tplinkcloud.com",
-    device_region: str      # "us-east-1",
-    device_id: str          # "80066F589AF56C3BED9C4C7F208433931DDF7861",
-    device_name: str        # "Smart Wi-Fi Plug Mini",
-    device_hw_ver: str      # "1.0",
-    alias: str              # "Wall-E",
-    device_mac: str         # "C0C9E30E44C7",
-    oem_id: str             # "9FDE0C9E37EDF4495F681216FEFB0CFB",
-    device_model: str       # "KP115(US)",
-    hw_id: str              # "3E2B9A976B98DCFC5C83D11C8CEF7510",
-    fw_id: str              # "00000000000000000000000000000000",
-    is_same_region: Optional[bool]   # true,
-    status: int             # 1
+    device_type: str
+    role: int
+    fw_ver: str
+    device_region: str
+    device_id: str
+    device_name: str
+    device_hw_ver: str
+    alias: str
+    device_mac: str
+    oem_id: str
+    device_model: str
+    hw_id: str
+    fw_id: str
+    is_same_region: Optional[bool]
+    status: int
+
 
 class Device(BaseModel):
     device_id: str
     device_info: DeviceInfo
+
 
 class DeviceResponse(BaseModel):
     data: List[Device] = []

--- a/app/models/device_response.py
+++ b/app/models/device_response.py
@@ -1,0 +1,27 @@
+from typing import List, Optional
+from pydantic import BaseModel
+
+class DeviceInfo(BaseModel):
+    device_type: str        # "IOT.SMARTPLUGSWITCH",
+    role: int               # 0,
+    fw_ver: str             # "1.0.17 Build 210506 Rel.075231",
+    #"app_server_url":"https://use1-wap.tplinkcloud.com",
+    device_region: str      # "us-east-1",
+    device_id: str          # "80066F589AF56C3BED9C4C7F208433931DDF7861",
+    device_name: str        # "Smart Wi-Fi Plug Mini",
+    device_hw_ver: str      # "1.0",
+    alias: str              # "Wall-E",
+    device_mac: str         # "C0C9E30E44C7",
+    oem_id: str             # "9FDE0C9E37EDF4495F681216FEFB0CFB",
+    device_model: str       # "KP115(US)",
+    hw_id: str              # "3E2B9A976B98DCFC5C83D11C8CEF7510",
+    fw_id: str              # "00000000000000000000000000000000",
+    is_same_region: Optional[bool]   # true,
+    status: int             # 1
+
+class Device(BaseModel):
+    device_id: str
+    device_info: DeviceInfo
+
+class DeviceResponse(BaseModel):
+    data: List[Device] = []

--- a/app/models/device_sys_info.py
+++ b/app/models/device_sys_info.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 from pydantic import BaseModel
 
+
 class DeviceSystemInfo(BaseModel):
     hw_ver: str
     err_code: int
@@ -17,6 +18,7 @@ class DeviceSystemInfo(BaseModel):
     active_mode: str
     hw_id: str
     sw_ver: str
+
 
 class DeviceSystemInfoResponse(BaseModel):
     data: DeviceSystemInfo

--- a/app/models/device_sys_info.py
+++ b/app/models/device_sys_info.py
@@ -1,0 +1,22 @@
+from typing import List, Optional
+from pydantic import BaseModel
+
+class DeviceSystemInfo(BaseModel):
+    hw_ver: str
+    err_code: int
+    device_id: str
+    updating: int
+    led_off: int
+    feature: str
+    on_time: int
+    relay_state: int
+    oem_id: str
+    alias: str
+    model: str
+    dev_name: str
+    active_mode: str
+    hw_id: str
+    sw_ver: str
+
+class DeviceSystemInfoResponse(BaseModel):
+    data: DeviceSystemInfo

--- a/app/routers/device.py
+++ b/app/routers/device.py
@@ -1,0 +1,30 @@
+import json
+from fastapi import APIRouter
+from fastapi import Depends
+
+from dependencies import oauth2_scheme
+from dependencies import root_path
+from services import TPLinkService
+from models import DeviceResponse
+
+router = APIRouter(
+    prefix=f'{root_path}/devices',
+    tags=['devices'],
+    dependencies=[],
+    responses={404: {'description': 'Not found'}}
+)
+
+def get_service(token: str = Depends(oauth2_scheme)):
+    tplink_service = TPLinkService()
+    tplink_service.set_auth_token(token)
+    return tplink_service
+
+@router.get('', response_model=DeviceResponse)
+def get_devices(tplink_service: TPLinkService = Depends(get_service)):
+    device_data = tplink_service.get_devices()
+
+    print(json.dumps(device_data))
+
+    return {
+        'data': device_data
+    }

--- a/app/routers/device.py
+++ b/app/routers/device.py
@@ -14,10 +14,12 @@ router = APIRouter(
     responses={404: {'description': 'Not found'}}
 )
 
+
 def get_service(token: str = Depends(oauth2_scheme)):
     tplink_service = TPLinkService()
     tplink_service.set_auth_token(token)
     return tplink_service
+
 
 @router.get('', response_model=DeviceResponse)
 def get_devices(tplink_service: TPLinkService = Depends(get_service)):
@@ -28,6 +30,7 @@ def get_devices(tplink_service: TPLinkService = Depends(get_service)):
     return {
         'data': device_data
     }
+
 
 @router.get('/{device_id}/systeminfo', response_model=DeviceSystemInfoResponse)
 def get_devices(device_id, tplink_service: TPLinkService = Depends(get_service)):

--- a/app/routers/device.py
+++ b/app/routers/device.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 from dependencies import oauth2_scheme
 from dependencies import root_path
 from services import TPLinkService
-from models import DeviceResponse
+from models import DeviceResponse, DeviceSystemInfoResponse
 
 router = APIRouter(
     prefix=f'{root_path}/devices',
@@ -22,6 +22,16 @@ def get_service(token: str = Depends(oauth2_scheme)):
 @router.get('', response_model=DeviceResponse)
 def get_devices(tplink_service: TPLinkService = Depends(get_service)):
     device_data = tplink_service.get_devices()
+
+    print(json.dumps(device_data))
+
+    return {
+        'data': device_data
+    }
+
+@router.get('/{device_id}/systeminfo', response_model=DeviceSystemInfoResponse)
+def get_devices(device_id, tplink_service: TPLinkService = Depends(get_service)):
+    device_data = tplink_service.get_device_sys_info(device_id)
 
     print(json.dumps(device_data))
 

--- a/app/services/tplink_service.py
+++ b/app/services/tplink_service.py
@@ -1,3 +1,4 @@
+from typing import List
 from tplinkcloud import TPLinkDeviceManager, TPLinkDeviceManagerPowerTools
 
 
@@ -67,6 +68,10 @@ class TPLinkService:
         )
 
         return self._jsonify(usage)
+
+    def get_devices(self):
+        device_data = self._device_manager.get_devices()
+        return self._jsonify(device_data)
 
     def _jsonify(self, data):
         if type(data) is list:

--- a/app/services/tplink_service.py
+++ b/app/services/tplink_service.py
@@ -69,6 +69,17 @@ class TPLinkService:
 
         return self._jsonify(usage)
 
+    def get_device_sys_info(self, device_id):
+        device_data = self._device_manager.get_devices()
+
+        device_sys_info = None
+        for device in device_data:
+            if device_id.lower() in device.device_id.lower():
+                device_sys_info = device.get_sys_info()
+                return self._jsonify(device_sys_info)
+        
+        return device_sys_info
+
     def get_devices(self):
         device_data = self._device_manager.get_devices()
         return self._jsonify(device_data)

--- a/app/services/tplink_service.py
+++ b/app/services/tplink_service.py
@@ -16,7 +16,8 @@ class TPLinkService:
             prefetch=False,
             verbose=True
         )
-        self._device_power_tools = TPLinkDeviceManagerPowerTools(self._device_manager)
+        self._device_power_tools = TPLinkDeviceManagerPowerTools(
+            self._device_manager)
 
         if auth_token:
             self._device_manager.set_auth_token(auth_token)
@@ -77,7 +78,7 @@ class TPLinkService:
             if device_id.lower() in device.device_id.lower():
                 device_sys_info = device.get_sys_info()
                 return self._jsonify(device_sys_info)
-        
+
         return device_sys_info
 
     def get_devices(self):


### PR DESCRIPTION
Resolves #23
https://github.com/piekstra/tplink-kasa-ui/issues/23

- Adds endpoint `{root_path}/devices` for fetching a thin list of endpoints
- Adds endpoint `{root_path}/devices/{device_id}/systeminfo` for fetching system info (including relay state, device name, etc.) for a specific device by ID.
