### PR TITLE
Add Workflow to Publish App to Heroku

### DIFF
--- a/.github/workflows/heroku-app-logs.yml
+++ b/.github/workflows/heroku-app-logs.yml
@@ -1,0 +1,20 @@
+name: Fetch Logs for Heroku App Deployment
+
+on:
+  workflow_dispatch:
+
+env:
+  HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+  HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
+  LOG_LINES: 200
+
+jobs:
+  build-push-and-release-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Fetch logs
+        run: heroku logs -a ${{ env.HEROKU_APP_NAME }} -n ${{ env.LOG_LINES }}

--- a/.github/workflows/heroku-app-logs.yml
+++ b/.github/workflows/heroku-app-logs.yml
@@ -13,8 +13,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - name: Fetch logs
         run: heroku logs -a ${{ env.HEROKU_APP_NAME }} -n ${{ env.LOG_LINES }}

--- a/.github/workflows/heroku-app-logs.yml
+++ b/.github/workflows/heroku-app-logs.yml
@@ -9,7 +9,7 @@ env:
   LOG_LINES: 200
 
 jobs:
-  build-push-and-release-image:
+  fetch-heroku-app-logs:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/package-publis-heroku.yml
+++ b/.github/workflows/package-publis-heroku.yml
@@ -6,10 +6,10 @@
 # Docs: https://devcenter.heroku.com/articles/container-registry-and-runtime
 # Guide: https://dev.to/heroku/deploying-to-heroku-from-github-actions-29ej
 
-name: Create and publish a Docker image to Heroku
+name: Create, publish, and deploy a Docker image to Heroku
 
 on:
-  release:
+  release:s
     types: [created]
 
 env:
@@ -17,11 +17,8 @@ env:
   HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
 
 jobs:
-  build-and-push-image:
+  build-push-and-release-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/package-publis-heroku.yml
+++ b/.github/workflows/package-publis-heroku.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# Docs: https://devcenter.heroku.com/articles/container-registry-and-runtime
+# Guide: https://dev.to/heroku/deploying-to-heroku-from-github-actions-29ej
+
+name: Create and publish a Docker image to Heroku
+
+on:
+  release:
+    types: [created]
+
+env:
+  HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+  HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - name: Login to the Heroku Container Registry
+        env: 
+        run: heroku container:login
+
+      - name: Build and push the container image
+        run: heroku container:push -a ${{ env.HEROKU_APP_NAME }} web 
+
+      - name: Deploy the release
+        run: heroku container:release -a ${{ env.HEROKU_APP_NAME }} web 

--- a/.github/workflows/package-publish-heroku.yml
+++ b/.github/workflows/package-publish-heroku.yml
@@ -9,7 +9,7 @@
 name: Create, publish, and deploy a Docker image to Heroku
 
 on:
-  release:s
+  release:
     types: [created]
 
 env:

--- a/.github/workflows/package-python.yml
+++ b/.github/workflows/package-python.yml
@@ -31,6 +31,7 @@ jobs:
       run: |
         docker build . -t apiserver
         docker run -d \
+          -e PORT=80 \
           -p 80:80 \
           apiserver
     - name: Install dependencies relevant to testing

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-FROM tiangolo/uvicorn-gunicorn:python3.8
+FROM python:3.9
 
 COPY ./app /app
-RUN pip install -U pip
-RUN pip install -r /app/requirements.txt
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir --upgrade -r requirements.txt
+
+CMD gunicorn -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT main:app

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /app
 
 RUN pip install --no-cache-dir --upgrade -r requirements.txt
 
-CMD gunicorn -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT main:app
+CMD gunicorn -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT main:app

--- a/README.md
+++ b/README.md
@@ -77,3 +77,12 @@ curl -X 'GET' \
 ### Swagger Authentication
 
 If calling the API through the Swagger documentation page, the consumer must first use the Authorize button at the top right passing the email and password credentials. Once authenticated in Swagger, subsequent calls do not currently require further identity context to be entered manually as they will be provided by the Swagger web client.
+
+## Service Deployment
+
+This service is currently deployed as a Heroku App and should be available [here][heroku-deployment].
+
+> Note that the `$PORT` environment variable indicated in the [`Dockerfile`](Dockerfile) is provided by Heroku per the documentation found [here](https://devcenter.heroku.com/articles/container-registry-and-runtime#get-the-port-from-the-environment-variable). For Heroku, the port is dynamic behind the scenes but for accessing the app's domain, no port specification is needed.
+
+
+[heroku-deployment]: https://tplinkcloud-service.herokuapp.com/docs

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ This project is built and tested with Python 3.7, 3.8, and 3.9.
 
 Download the latest version of Python [here](https://www.python.org/downloads/).
 
-### Uvicorn
+### Gunicorn
 
-Uvicorn is an HTTP server implementation which will be installed by running `pip install -r requirements.txt` from a terminal running in the [app directory](./app/).
+Gunicorn is a Python WSGI HTTP Server for UNIX which will be installed by running `pip install -r requirements.txt` from a terminal running in the [app directory](./app/).
 
-Read more about Uvicorn [here](https://www.uvicorn.org/).
+Read more about Gunicorn [here](https://gunicorn.org/).
 
 ## Environment
 
@@ -28,7 +28,7 @@ You may need to setup environment variables with proper values in a `.env` file.
 
 ## Running the API for Development
 
-From the [app](app) folder, you can simply run `uvicorn main:app --reload` to serve the API in development mode.
+From the [app](app) folder, you can simply run `gunicorn -k uvicorn.workers.UvicornWorker main:app --reload` to serve the API in development mode.
 
 The app's Swagger page will then be available at http://localhost:8000/docs
 
@@ -40,6 +40,7 @@ You can leverage the [`Dockerfile`](Dockerfile) to run the API using the followi
 docker build . -t apiserver
 
 docker run -d \
+    -e PORT=80 \
     -p 80:80 \
     apiserver
 ```
@@ -50,7 +51,7 @@ This can be useful to leverage the same process as the GitHub Actions Workflow f
 
 ## Service Discovery
 
-Swagger is available at the `/docs` URL. If running locally, this would be accessed at [here](http://localhost:8000/docs).
+Swagger is available at the `/docs` URL. If running locally, this would be accessed [here](http://localhost:8000/docs), otherwise if run as a docker container, [here](http://localhost/docs).
 
 ## Authentication
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,6 +2,7 @@ python-dotenv==0.19.0
 tplink-cloud-api==3.0.0
 fastapi==0.68.0
 uvicorn==0.15.0
+gunicorn==20.1.0
 
 # For creating models and performing data validation
 # https://fastapi.tiangolo.com/python-types/#pydantic-models


### PR DESCRIPTION
This process should handle the deployment automatically when releases are made.

This also includes a workflow intended to capture logs for the Heroku App and only be run manually when needed.

Please reach out to me for access to the app in Heroku where necessary. 

> Note that this changes the startup command to use `gunicorn` instead of `uvicorn` for performance reasons and easier compatibility with the Heroku deployment. Gunicorn essentially manages Uvicorn workers for us in the production setting.

> Also note that we are no longer using the `tiangolo` image per their own guidance here: https://github.com/tiangolo/uvicorn-gunicorn-docker#-warning-you-probably-dont-need-this-docker-image