### PR TITLE
Trigger workflow on release published

### DIFF
--- a/.github/workflows/package-publish-heroku.yml
+++ b/.github/workflows/package-publish-heroku.yml
@@ -10,7 +10,7 @@ name: Create, publish, and deploy a Docker image to Heroku
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 env:
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -12,7 +12,7 @@ name: Create and publish a Docker image
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
A draft release was created and then moved into an official release and these workflows did not trigger - we need to change the trigger for when a release is completed (`published`)